### PR TITLE
기업정보 - 기업회원 연관관계 매핑시 FK를 기원회원 PK로 변경

### DIFF
--- a/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/dto/EnterpriseInfoResponseDTO.java
+++ b/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/dto/EnterpriseInfoResponseDTO.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 public class EnterpriseInfoResponseDTO {
 	
 	// 기업Id
-	private Integer enterpriseId;
+	private Long enterpriseId;
 	
 	// 기업명
 	private String enterpriseName;
@@ -55,7 +55,7 @@ public class EnterpriseInfoResponseDTO {
 	private Integer averageSalary;
 	
 	@Builder
-	public EnterpriseInfoResponseDTO(Integer enterpriseId, String enterpriseName, String companyNumber, String managerName, String contact,
+	public EnterpriseInfoResponseDTO(Long enterpriseId, String enterpriseName, String companyNumber, String managerName, String contact,
 			String fsIndustryCode, String fsIndustry, String scIndustryCode, String scIndustry, String address,
 			String establishDate, String enterpriseTypeCode, String enterpriseType, Integer employees,
 			Integer averageSalary) {

--- a/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/entity/EnterpriseInfo.java
+++ b/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/entity/EnterpriseInfo.java
@@ -31,7 +31,7 @@ public class EnterpriseInfo {
     @Id
     @Column(name = "ENTERPRISE_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Integer enterpriseId;
+    private Long enterpriseId;
 
     // 기업명
     @Column(name = "ENTERPRISE_NAME" ,nullable = false ,length = 64)
@@ -82,11 +82,11 @@ public class EnterpriseInfo {
     private String updateDate;
     
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "USER_ID", referencedColumnName = "USER_ID", unique = true) // 외래키를 PK가 아닌 user_id로 설정
+    @JoinColumn(name = "ENTERPRISE_USER_ID") // 외래키를 PK가 아닌 user_id로 설정
     private EnterpriseUser enterpriseUser;
 
     @Builder
-	public EnterpriseInfo(Integer enterpriseId, String enterpriseName, String companyNumber, String fsIndustryCode,
+	public EnterpriseInfo(Long enterpriseId, String enterpriseName, String companyNumber, String fsIndustryCode,
 			String scIndustryCode, String managerName, String contact, String address, String establishDate,
 			String enterpriseTypeCode, Integer employees, Integer averageSalary, String updateDate, EnterpriseUser enterpriseUser) {
 		super();

--- a/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/entity/EnterpriseInfo.java
+++ b/JOBGO-COMMON/src/main/java/com/flab/jobgo/common/entity/EnterpriseInfo.java
@@ -82,7 +82,7 @@ public class EnterpriseInfo {
     private String updateDate;
     
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ENTERPRISE_USER_ID") // 외래키를 PK가 아닌 user_id로 설정
+    @JoinColumn(name = "ENTERPRISE_USER_ID")
     private EnterpriseUser enterpriseUser;
 
     @Builder

--- a/JOBGO-ENTERPRISE-SERVICE/src/main/resources/application.yml
+++ b/JOBGO-ENTERPRISE-SERVICE/src/main/resources/application.yml
@@ -1,3 +1,5 @@
+server:
+  port: 8081
 ## DataSource
 spring:
   profiles:


### PR DESCRIPTION
## 이슈사항
* 기업정보 - 기업회원 연관관계 매핑시 FK를 PK가 아닌 기업회원의 user_id로 설정하여 기업정보 조회시 불필요한 쿼리 발생하는 이슈

## 변경사항
* 기업정보 - 기업회원 연관관계 매핑시 FK를 기업회원 PK로 변경하여 문제해결